### PR TITLE
Update `getCoreAssetsJSModulesPath` to reflect move to static

### DIFF
--- a/public/static/assets/jquery-detached/jsmodules/jquery2.js
+++ b/public/static/assets/jquery-detached/jsmodules/jquery2.js
@@ -700,7 +700,7 @@ exports.getPluginJSModulesPath = function(pluginId) {
 };
 
 exports.getCoreAssetsJSModulesPath = function(namespace) {
-    return getRootURL() + '/assets/' + namespace + '/jsmodules';
+    return getRootURL() + 'static/assets/' + namespace + '/jsmodules';
 };
 
 exports.getPluginPath = function(pluginId) {


### PR DESCRIPTION
Hi @pietervogelaar 

Thanks for this dashboard, it's super useful.
I was having issues running v0.2.0 where I'm getting a 404 on 
 `<KUBERNETES_DASHBOARD_URL>/assets/jquery-detached/jsmodules/jquery2.js`


I'm not 100% sure, but I think this was introduced in https://github.com/pietervogelaar/kubernetes-job-monitor/commit/a1d18cfe4aafb43fb5a85e3aa6efd02c87bb2ca8 and this would fix it

A `GET` request on
 `<KUBERNETES_DASHBOARD_URL>/static/assets/jquery-detached/jsmodules/jquery2.js`
works for me